### PR TITLE
Add Umbraco option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ scaffold <project-name>
 ```
 scaffold <project-name>
 
---name        The application name.
---cwd         A directory to use instead of $PWD.
---install     Installs dependencies.                                [boolean] [default: true]
+--name                  The application name.
+--umbraco <version>     Install the @stormid/umbraco-library        [npm version] [default: latest]
+--cwd                   A directory to use instead of $PWD.
+--install               Installs dependencies.                      [boolean] [default: true]
 ``` 

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -1,4 +1,4 @@
-const { info, warn, error, isDir, install, initGit } = require('../utils');
+const { info, warn, error, isDir, install, initGit, npmCheck } = require('../utils');
 const { resolve } = require('path');
 const figlet = require('figlet');
 const gittar = require('gittar');
@@ -42,6 +42,17 @@ module.exports = async function(dest, argv) {
 			1
 		);
     });
+
+    if (argv['umbraco']) {
+        if (argv['umbraco'] === true) info(`-> Adding Umbraco Library`);
+        else {
+            const packageExists = await npmCheck('@stormid/umbraco-library', argv['umbraco']);
+            if (packageExists) info(`-> Adding Umbraco Library version ${argv['umbraco']}`);
+            else {
+                return error(`-> Cannot find Umbraco Library version '${argv['umbraco']}'`);
+            }
+        }
+    }
     
     info('-> Creating project');
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,6 +27,6 @@ sade('scaffold [dest]', true)
 	.option('--cwd', 'A directory to use instead of $PWD', '.')
 	.option('--install', 'Install dependencies', true)
 	.option('-v, --verbose', 'Verbose output')
-	.option('--umbraco', 'Include the Umbraco library', false)
+	.option('--umbraco', 'Include the Umbraco library')
     .action(require('./commands'))
     .parse(process.argv);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,6 +2,9 @@ const { blue, yellow, red } = require('kleur');
 const { statSync, existsSync } = require('fs');
 const which = require('which');
 const spawn = require('cross-spawn-promise');
+const npmName = require('npm-name');
+const fetch = require('node-fetch');
+
 const hasCommand = function(str) {
 	return !!which.sync(str, { nothrow: true });
 };
@@ -74,3 +77,19 @@ exports.initGit = async function(target) {
 		warn('Could not locate `git` binary in `$PATH`. Skipping...');
 	}
 };
+
+exports.npmCheck = (module, version) =>
+  new Promise((resolve, reject) => {
+    return npmName(module)
+      .then(isNoValid => {
+        if (isNoValid)
+          throw new Error(`Error > Cannot find ${module} in the NPM registry`)
+
+        fetch(`http://registry.npmjs.org/${module}`)
+          .then(res => res.json())
+          .then(body => {
+            return resolve({}.hasOwnProperty.call(body.time, version))
+          })
+      })
+      .catch(err => reject(err.message))
+  })

--- a/package.json
+++ b/package.json
@@ -23,9 +23,6 @@
     "system",
     "generator"
   ],
-  "devDependencies": {
-    "jest": "^24.8.0"
-  },
   "dependencies": {
     "cli-table": "^0.3.1",
     "cross-spawn-promise": "^0.10.1",
@@ -33,6 +30,8 @@
     "fs-extra": "^8.1.0",
     "gittar": "^0.1.1",
     "kleur": "^3.0.3",
+    "node-fetch": "^2.6.7",
+    "npm-name": "^6.0.1",
     "ora": "^3.4.0",
     "sade": "^1.6.1",
     "validate-npm-package-name": "^3.0.0",


### PR DESCRIPTION
Adds an option to include the @stormid/umbraco-library package.

The current CLI framework does not support prompts, so this implementation uses a flag on the command:
`scaffold test-app --umbraco` will install the latest umbraco-library package 
`scaffold test-app --umbraco 1.0.1` will install the umbraco-library package version 1.0.1

If we think that a prompt is preferable, then there are alternative frameworks that could be used, but that is slightly larger piece of work.